### PR TITLE
Develop

### DIFF
--- a/.templates/default_offline_template.txt
+++ b/.templates/default_offline_template.txt
@@ -5,3 +5,4 @@
 
 配信者: {{ broadcaster_user_name }} ({{ broadcaster_user_login }})
 チャンネルURL: {{ channel_url }}
+終了時刻: {{ ended_at | datetimeformat }}

--- a/bluesky.py
+++ b/bluesky.py
@@ -6,13 +6,14 @@ Stream notify on Bluesky
 """
 
 from datetime import datetime
-from utils import retry_on_exception, is_valid_url, format_datetime_filter, notify_discord_error
+from utils import retry_on_exception, is_valid_url, notify_discord_error
 # is_valid_url: URLがhttp/httpsで始まるか判定するユーティリティ関数。他モジュールからも利用されるため削除不可。
 import os
 import csv
 import logging
 from atproto import Client, exceptions
-from jinja2 import Template
+from jinja2 import Environment, Template
+from utils import format_datetime_filter
 from version_info import __version__
 
 __author__ = "mayuneco(mayunya)"
@@ -69,10 +70,10 @@ def load_template(path=None):
         logger.error(f"テンプレート '{path}' の読み込み中に予期せぬエラー: {e}", exc_info=True)
         template_string = "Error: Failed to load template '{{ template_path }}' due to an unexpected error."
 
-    # Jinja2 Templateオブジェクトを生成
-    template_obj = Template(template_string)
-    # カスタムフィルタをテンプレート環境に追加
-    template_obj.environment.filters['datetimeformat'] = format_datetime_filter
+    # Jinja2 Environmentを使い、グローバルにフィルターを登録
+    env = Environment()
+    env.filters['datetimeformat'] = format_datetime_filter
+    template_obj = env.from_string(template_string)
     return template_obj
 
 

--- a/document/投稿テンプレートの引数.md
+++ b/document/投稿テンプレートの引数.md
@@ -3,10 +3,10 @@
 ### 【放送開始（stream.online）】
 - `{{ broadcaster_user_login}} ` … 配信者のログイン名（英数字ID）
 - `{{ broadcaster_user_name }}` … 配信者の表示名（日本語/英語名）
-- `{{ title }}` … 配信タイトル
+- `{{ title }}` … 放送タイトル
 - `{{ category_name }}` … カテゴリ名（例: Just Chatting）
 - `{{ game_name }}` … ゲーム名（通常はcategory_nameと同じ）
-- `{{ language }}` … 配信言語
+- `{{ started_at }}` … 放送開始日時（サーバー受信時刻、ISO8601形式）
 - `{{ stream_url }}` … 視聴URL（例: https://twitch.tv/xxxx）
 
 ---
@@ -15,18 +15,18 @@
 - `{{ broadcaster_user_login }}`
 - `{{ broadcaster_user_name }}`
 - `{{ channel_url }}` … チャンネルURL（例: https://twitch.tv/xxxx）
-- `{{ ended_at }}` … 終了時刻（サーバー受信時刻、ISO8601形式）
+- `{{ ended_at }}` … 放送終了日時（サーバー受信時刻、ISO8601形式）
+- `{{ to_broadcaster_user_name }}` … Raid先の配信者名（Raid時のみ）
+- `{{ to_broadcaster_user_login }}` … Raid先のログイン名（Raid時のみ）
+- `{{ to_stream_url }}` … Raid先の配信URL（Raid時のみ）
 
 ---
 
 ### 【Raidによる配信終了（channel.raid outgoing）】
-- `{{ from_broadcaster_user_id }}` … Raid元の配信者ID
 - `{{ from_broadcaster_user_login }}` … Raid元の配信者ログイン名
 - `{{ from_broadcaster_user_name }}` … Raid元の配信者表示名
-- `{{ to_broadcaster_user_id }}` … Raid先の配信者ID
 - `{{ to_broadcaster_user_login }}` … Raid先の配信者ログイン名
 - `{{ to_broadcaster_user_name }}` … Raid先の配信者表示名
-- `{{ viewers }}` … Raidで送られた視聴者数
 - `{{ raid_url }}` … Raid先の配信URL（https://twitch.tv/{{ to_broadcaster_user_login }}）
 
 ---
@@ -77,6 +77,30 @@
 - `{{ video_url }}`（URL）
 - `{{ author }}`（投稿者名）
 - `{{ published }}`（投稿日時）
+
+---
+
+### 【Twitch配信終了通知の汎用テンプレート例（Raid対応）】
+
+```
+🛑 Twitch 配信終了
+
+{{ broadcaster_user_name | default('配信者名不明') }} さんのTwitch配信が終わりました。
+チャンネル: {{ channel_url | default('チャンネルURL不明') }}
+終了時刻: {{ ended_at | datetimeformat }}
+
+{% if to_broadcaster_user_name %}
+---
+Raid先: {{ to_broadcaster_user_name }}（{{ to_stream_url }}）
+{% endif %}
+
+またの配信をお楽しみに！
+#Twitch #配信終了
+```
+
+- `to_broadcaster_user_name` などRaid関連変数が存在する場合のみRaid情報が表示されます。
+- 通常終了時はRaid部分は表示されません。
+- Jinja2の`{% if %}`構文で柔軟にカスタマイズ可能です。
 
 
 

--- a/document/投稿テンプレートの引数.md
+++ b/document/投稿テンプレートの引数.md
@@ -15,6 +15,19 @@
 - `{{ broadcaster_user_login }}`
 - `{{ broadcaster_user_name }}`
 - `{{ channel_url }}` … チャンネルURL（例: https://twitch.tv/xxxx）
+- `{{ ended_at }}` … 終了時刻（サーバー受信時刻、ISO8601形式）
+
+---
+
+### 【Raidによる配信終了（channel.raid outgoing）】
+- `{{ from_broadcaster_user_id }}` … Raid元の配信者ID
+- `{{ from_broadcaster_user_login }}` … Raid元の配信者ログイン名
+- `{{ from_broadcaster_user_name }}` … Raid元の配信者表示名
+- `{{ to_broadcaster_user_id }}` … Raid先の配信者ID
+- `{{ to_broadcaster_user_login }}` … Raid先の配信者ログイン名
+- `{{ to_broadcaster_user_name }}` … Raid先の配信者表示名
+- `{{ viewers }}` … Raidで送られた視聴者数
+- `{{ raid_url }}` … Raid先の配信URL（https://twitch.tv/{{ to_broadcaster_user_login }}）
 
 ---
 

--- a/eventsub.py
+++ b/eventsub.py
@@ -429,3 +429,27 @@ def cleanup_eventsub_subscriptions(webhook_callback_url, logger_to_use=None):
 
     current_logger.info(
         f"EventSubサブスクリプションのクリーンアップ完了。{deleted_count}件のサブスクリプションを削除しました。")
+
+def get_channel_information(broadcaster_user_id, logger_to_use=None):
+    """
+    Twitch API Get Channel Informationエンドポイントを使い、
+    指定ユーザーIDの配信タイトル・カテゴリ名（game_name）等を取得する
+    """
+    current_logger = logger_to_use if logger_to_use else logger
+    url = "https://api.twitch.tv/helix/channels"
+    headers = {
+        "Client-ID": TWITCH_CLIENT_ID,
+        "Authorization": f"Bearer {get_valid_app_access_token(logger_to_use=current_logger)}",
+    }
+    params = {"broadcaster_id": broadcaster_user_id}
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json().get("data", [])
+        if not data or not isinstance(data, list):
+            current_logger.warning(f"Twitch API Get Channel Information: データが空です (broadcaster_id: {broadcaster_user_id})")
+            return {}
+        return data[0]
+    except Exception as e:
+        current_logger.error(f"Twitch API Get Channel Information取得失敗: {e}")
+        return {}

--- a/gui/bluesky_post_settings_frame.py
+++ b/gui/bluesky_post_settings_frame.py
@@ -77,8 +77,8 @@ class BlueskyPostSettingsFrame(ctk.CTkFrame):
             def on_save(new_path):
                 # 保存したファイルのパスをセット
                 initial_text_var.set(new_path)
-            # TemplateEditorDialogのon_saveにファイルパスを渡すようにする
-            TemplateEditorDialog(self, template_type=template_type, initial_text=initial_text_var.get(), on_save=on_save)
+            # 新規作成時は空欄でエディタを開く
+            TemplateEditorDialog(self, template_type=template_type, initial_text="", on_save=on_save)
         for tab_name, template_type, var_attr in [
             ("Twitch", "twitch_online", getattr(self.twitch_frame, "tpl_online", None)),
             ("YouTube", "yt_online", getattr(self.youtube_frame, "tpl_online", None)),

--- a/gui/bluesky_post_settings_frame.py
+++ b/gui/bluesky_post_settings_frame.py
@@ -74,8 +74,11 @@ class BlueskyPostSettingsFrame(ctk.CTkFrame):
         # サービス欄にテンプレート編集ボタン（有効化）を追加
         from .template_editor_dialog import TemplateEditorDialog
         def open_template_editor(template_type, initial_text_var):
-            def on_save(new_text):
-                initial_text_var.set(new_text)
+            def on_save(new_path):
+                # 保存したファイルのパスをセット
+                initial_text_var.set(new_path)
+            # TemplateEditorDialogのon_saveにファイルパスを渡すようにする
+            # TemplateEditorDialog側もon_save(tpl)→on_save(self.file_path)に修正が必要
             TemplateEditorDialog(self, template_type=template_type, initial_text=initial_text_var.get(), on_save=on_save)
         for tab_name, template_type, var_attr in [
             ("Twitch", "twitch_online", getattr(self.twitch_frame, "tpl_online", None)),

--- a/gui/bluesky_post_settings_frame.py
+++ b/gui/bluesky_post_settings_frame.py
@@ -71,14 +71,13 @@ class BlueskyPostSettingsFrame(ctk.CTkFrame):
         self.nico_frame = NiconicoNoticeFrame(tabview)
         self.nico_frame.pack(fill="both", expand=True, padx=10, pady=10, in_=tabview.tab("ニコニコ"))
 
-        # サービス欄にテンプレート編集ボタン（有効化）を追加
+        # サービス欄にテンプレート作成ボタン（有効化）を追加
         from .template_editor_dialog import TemplateEditorDialog
-        def open_template_editor(template_type, initial_text_var):
+        def open_template_creator(template_type, initial_text_var):
             def on_save(new_path):
                 # 保存したファイルのパスをセット
                 initial_text_var.set(new_path)
             # TemplateEditorDialogのon_saveにファイルパスを渡すようにする
-            # TemplateEditorDialog側もon_save(tpl)→on_save(self.file_path)に修正が必要
             TemplateEditorDialog(self, template_type=template_type, initial_text=initial_text_var.get(), on_save=on_save)
         for tab_name, template_type, var_attr in [
             ("Twitch", "twitch_online", getattr(self.twitch_frame, "tpl_online", None)),
@@ -87,9 +86,9 @@ class BlueskyPostSettingsFrame(ctk.CTkFrame):
         ]:
             tab = tabview.tab(tab_name)
             if var_attr is not None:
-                edit_btn = ctk.CTkButton(tab, text="テンプレート編集", state="normal", font=DEFAULT_FONT, width=180,
-                                         command=lambda t=template_type, v=var_attr: open_template_editor(t, v))
-                edit_btn.pack(anchor="ne", padx=10, pady=(5, 0))
+                create_btn = ctk.CTkButton(tab, text="テンプレート作成", state="normal", font=DEFAULT_FONT, width=180,
+                                         command=lambda t=template_type, v=var_attr: open_template_creator(t, v))
+                create_btn.pack(anchor="ne", padx=10, pady=(5, 0))
 
         # タブボタンのサイズとフォントを変更
         for button in tabview._segmented_button._buttons_dict.values():

--- a/gui/niconico_notice_frame.py
+++ b/gui/niconico_notice_frame.py
@@ -73,10 +73,12 @@ class NiconicoNoticeFrame(ctk.CTkFrame):
         ctk.CTkLabel(self, text="放送開始時テンプレート:", font=DEFAULT_FONT).grid(row=2, column=0, sticky="w")
         self.lbl_online_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_online.get()), font=DEFAULT_FONT)
         self.lbl_online_tpl.grid(row=2, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_online, font=DEFAULT_FONT, width=140).grid(row=3, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_online, font=DEFAULT_FONT, width=140).grid(row=3, column=1, sticky="w", pady=(0, 10))
         ctk.CTkLabel(self, text="動画投稿時テンプレート:", font=DEFAULT_FONT).grid(row=4, column=0, sticky="w")
         self.lbl_newvideo_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_newvideo.get()), font=DEFAULT_FONT)
         self.lbl_newvideo_tpl.grid(row=4, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_newvideo, font=DEFAULT_FONT, width=140).grid(row=5, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_newvideo, font=DEFAULT_FONT, width=140).grid(row=5, column=1, sticky="w", pady=(0, 10))
         ctk.CTkLabel(self, text="画像ファイル:", font=DEFAULT_FONT).grid(row=6, column=0, sticky="w")
         self.img_preview = ctk.CTkLabel(self, width=200, height=112.5, text="", fg_color="white")
@@ -198,3 +200,33 @@ class NiconicoNoticeFrame(ctk.CTkFrame):
         from gui.app_gui import show_ctk_info
         show_ctk_info(self, '保存完了', 'ニコニコ通知設定を保存しました。')
         self.status_label.configure(text="保存しました")
+
+    def open_template_editor_online(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_online.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_online.set(new_path)
+        TemplateEditorDialog(self, template_type="niconico_online", initial_text=initial_text, on_save=on_save, initial_path=path)
+
+    def open_template_editor_newvideo(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_newvideo.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_newvideo.set(new_path)
+        TemplateEditorDialog(self, template_type="niconico_new_video", initial_text=initial_text, on_save=on_save, initial_path=path)

--- a/gui/template_editor_dialog.py
+++ b/gui/template_editor_dialog.py
@@ -13,10 +13,11 @@ DEFAULT_FONT = ("Yu Gothic UI", 12, "normal")
 # サンプル event_context（サービス・通知種別ごとに適宜拡張）
 SAMPLE_CONTEXT = {
     "twitch_online": {
-        "language": "日本語(japanese)",
-        "user_name": "hogehoge",
+        "broadcaster_user_name": "hogehoge",
         "title": "テスト配信",
         "game_name": "ゲームタイトル",
+        "category_name": "カテゴリ名",
+        "started_at": "開始日時",
         "url": "https://twitch.tv/sample",
     },
     "yt_online": {
@@ -48,7 +49,9 @@ SAMPLE_CONTEXT = {
 }
 # 除外リスト
 TEMPLATE_VAR_BLACKLIST = {
-    "twitch_online": {"broadcaster_user_id", "game_id", "started_at", "type", "is_mature", "tags"},
+    "twitch_online": {"id", "broadcaster_user_id", "type"},
+    "twitch_offline": {"broadcaster_user_id"},
+    "twitch_raid": {"from_broadcaster_user_id", "to_broadcaster_user_id", "viewers"},
     "yt_online": {"channel_id", "channel_name", "thumbnail_url", "description", "start_time"},
 }
 # --- テンプレート引数（日本語ラベル付きボタン群）定義 ---
@@ -58,12 +61,24 @@ TEMPLATE_ARGS = {
         ("タイトル", "title"),
         ("カテゴリ", "category_name"),
         ("ゲーム名", "game_name"),
-        ("言語", "language"),
+        ("開始日時", "started_at"),
         ("URL", "stream_url"),
     ],
     "twitch_offline": [
         ("配信者名", "broadcaster_user_name"),
-        ("URL", "stream_url"),
+        ("終了日時", "ended_at"),
+        ("URL", "channel_url"),
+        ("Raid先配信者名", "to_broadcaster_user_name"),
+        ("Raid先ログイン名", "to_broadcaster_user_login"),
+        ("Raid先URL", "to_stream_url"),
+    ],
+    "twitch_raid": [
+        ("Raid元配信者名", "from_broadcaster_user_name"),
+        ("Raid元ログイン名", "from_broadcaster_user_login"),
+        ("Raid先配信者名", "to_broadcaster_user_name"),
+        ("Raid先ログイン名", "to_broadcaster_user_login"),
+        ("Raid先URL", "raid_url"),
+        ("視聴者数", "viewers"),
     ],
     # --- YouTube用を追加 ---
     "yt_online": [

--- a/gui/template_editor_dialog.py
+++ b/gui/template_editor_dialog.py
@@ -179,6 +179,7 @@ class TemplateEditorDialog(ctk.CTkToplevel):
         ctk.CTkButton(frame_btn, text="キャンセル", command=self.on_cancel, font=DEFAULT_FONT, width=90).pack(side="left")
 
     def _get_file_label(self):
+        # ファイル名以外（特にテンプレート本文）は絶対にセットしないこと
         return f"ファイル: {os.path.basename(self.file_path) if self.file_path else '(未保存)'}"
 
     def get_template_dir(self):
@@ -204,7 +205,7 @@ class TemplateEditorDialog(ctk.CTkToplevel):
                 self.text_area.delete("1.0", tk.END)
                 self.text_area.insert("1.0", text)
                 self.file_path = path
-                self.file_label.configure(text=self._get_file_label())
+                self.file_label.configure(text=self._get_file_label())  # ファイル名のみ表示
                 self.update_preview()
                 # --- 追加: ファイルを開いた後も前面に出す ---
                 self.lift()
@@ -256,7 +257,7 @@ class TemplateEditorDialog(ctk.CTkToplevel):
                 messagebox.showerror("保存エラー", str(e))
                 return
         if self.on_save:
-            self.on_save(tpl)
+            self.on_save(self.file_path)  # ファイルパスを渡す
         self.destroy()
 
     def on_saveas(self):
@@ -277,8 +278,11 @@ class TemplateEditorDialog(ctk.CTkToplevel):
                 with open(path, 'w', encoding='utf-8') as f:
                     f.write(tpl)
                 self.file_path = path
-                self.file_label.configure(text=self._get_file_label())
+                self.file_label.configure(text=self._get_file_label())  # ファイル名のみ表示
                 messagebox.showinfo("保存完了", f"{os.path.basename(path)} に保存しました。")
+                if self.on_save:
+                    self.on_save(self.file_path)  # ファイルパスを渡す
+                self.destroy()
             except Exception as e:
                 messagebox.showerror("保存エラー", str(e))
 

--- a/gui/twitch_notice_frame.py
+++ b/gui/twitch_notice_frame.py
@@ -83,13 +83,6 @@ class TwitchNoticeFrame(ctk.CTkFrame):
         self.lbl_offline_tpl.grid(row=4, column=1, sticky="w")
         ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_offline, font=DEFAULT_FONT, width=140).grid(row=5, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_offline, font=DEFAULT_FONT, width=140).grid(row=5, column=1, sticky="w", pady=(0, 10))
-        # --- 下部にテンプレート作成ボタン ---
-        from .template_editor_dialog import TemplateEditorDialog
-        def create_new_template():
-            def on_save(new_path):
-                pass  # 新規作成時は何もしない
-            TemplateEditorDialog(self, template_type="twitch_offline", initial_text="", on_save=on_save, initial_path=None)
-        ctk.CTkButton(self, text="テンプレート作成", command=create_new_template, font=DEFAULT_FONT, width=180).grid(row=20, column=1, sticky="e", pady=(20, 10))
         ctk.CTkLabel(self, text="画像ファイル:", font=DEFAULT_FONT).grid(row=6, column=0, columnspan=2, sticky="w")
         self.img_preview = ctk.CTkLabel(self, width=200, height=112.5, text="", fg_color="white", image=None)
         self.img_preview._image = None  # Prevent garbage collection, 明示的に初期化

--- a/gui/twitch_notice_frame.py
+++ b/gui/twitch_notice_frame.py
@@ -76,11 +76,20 @@ class TwitchNoticeFrame(ctk.CTkFrame):
         ctk.CTkLabel(self, text="放送開始時投稿テンプレート:", font=DEFAULT_FONT).grid(row=2, column=0, sticky="w")
         self.lbl_online_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_online.get()), font=DEFAULT_FONT)
         self.lbl_online_tpl.grid(row=2, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_online, font=DEFAULT_FONT, width=140).grid(row=3, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_online, font=DEFAULT_FONT, width=140).grid(row=3, column=1, sticky="w", pady=(0, 10))
         ctk.CTkLabel(self, text="放送終了時投稿テンプレート:", font=DEFAULT_FONT).grid(row=4, column=0, sticky="w")
         self.lbl_offline_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_offline.get()), font=DEFAULT_FONT)
         self.lbl_offline_tpl.grid(row=4, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_offline, font=DEFAULT_FONT, width=140).grid(row=5, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_offline, font=DEFAULT_FONT, width=140).grid(row=5, column=1, sticky="w", pady=(0, 10))
+        # --- 下部にテンプレート作成ボタン ---
+        from .template_editor_dialog import TemplateEditorDialog
+        def create_new_template():
+            def on_save(new_path):
+                pass  # 新規作成時は何もしない
+            TemplateEditorDialog(self, template_type="twitch_offline", initial_text="", on_save=on_save, initial_path=None)
+        ctk.CTkButton(self, text="テンプレート作成", command=create_new_template, font=DEFAULT_FONT, width=180).grid(row=20, column=1, sticky="e", pady=(20, 10))
         ctk.CTkLabel(self, text="画像ファイル:", font=DEFAULT_FONT).grid(row=6, column=0, columnspan=2, sticky="w")
         self.img_preview = ctk.CTkLabel(self, width=200, height=112.5, text="", fg_color="white", image=None)
         self.img_preview._image = None  # Prevent garbage collection, 明示的に初期化
@@ -204,3 +213,33 @@ class TwitchNoticeFrame(ctk.CTkFrame):
         from gui.app_gui import show_ctk_info
         show_ctk_info(self, '保存完了', 'Twitch通知設定を保存しました。')
         self.status_label.configure(text="保存しました")
+
+    def open_template_editor_online(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_online.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_online.set(new_path)
+        TemplateEditorDialog(self, template_type="twitch_online", initial_text=initial_text, on_save=on_save, initial_path=path)
+
+    def open_template_editor_offline(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_offline.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_offline.set(new_path)
+        TemplateEditorDialog(self, template_type="twitch_offline", initial_text=initial_text, on_save=on_save, initial_path=path)

--- a/gui/youtube_notice_frame.py
+++ b/gui/youtube_notice_frame.py
@@ -80,16 +80,19 @@ class YouTubeNoticeFrame(ctk.CTkFrame):
         ctk.CTkLabel(self, text="放送開始時投稿テンプレート:", font=DEFAULT_FONT).grid(row=3, column=0, sticky="w")
         self.lbl_online_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_online.get()), font=DEFAULT_FONT)
         self.lbl_online_tpl.grid(row=3, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_online, font=DEFAULT_FONT, width=140).grid(row=4, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_online, font=DEFAULT_FONT, width=140).grid(row=4, column=1, sticky="w", pady=(0, 10))
         # テンプレート選択（終了）
         ctk.CTkLabel(self, text="放送終了時投稿テンプレート:", font=DEFAULT_FONT).grid(row=5, column=0, sticky="w")
         self.lbl_offline_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_offline.get()), font=DEFAULT_FONT)
         self.lbl_offline_tpl.grid(row=5, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_offline, font=DEFAULT_FONT, width=140).grid(row=6, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_offline, font=DEFAULT_FONT, width=140).grid(row=6, column=1, sticky="w", pady=(0, 10))
         # テンプレート選択（新着動画）
         ctk.CTkLabel(self, text="動画投稿時テンプレート:", font=DEFAULT_FONT).grid(row=7, column=0, sticky="w")
         self.lbl_newvideo_tpl = ctk.CTkLabel(self, text=os.path.basename(self.tpl_newvideo.get()), font=DEFAULT_FONT)
         self.lbl_newvideo_tpl.grid(row=7, column=1, sticky="w")
+        ctk.CTkButton(self, text="テンプレート編集", command=self.open_template_editor_newvideo, font=DEFAULT_FONT, width=140).grid(row=8, column=0, sticky="w", pady=(0, 10))
         ctk.CTkButton(self, text="テンプレート変更...", command=self.change_template_file_newvideo, font=DEFAULT_FONT, width=140).grid(row=8, column=1, sticky="w", pady=(0, 10))
         # 画像
         ctk.CTkLabel(self, text="画像ファイル:", font=DEFAULT_FONT).grid(row=9, column=0, sticky="w")
@@ -232,3 +235,48 @@ class YouTubeNoticeFrame(ctk.CTkFrame):
         from gui.app_gui import show_ctk_info
         show_ctk_info(self, '保存完了', 'YouTube通知設定を保存しました。')
         self.status_label.configure(text="保存しました")
+
+    def open_template_editor_online(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_online.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_online.set(new_path)
+        TemplateEditorDialog(self, template_type="yt_online", initial_text=initial_text, on_save=on_save, initial_path=path)
+
+    def open_template_editor_offline(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_offline.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_offline.set(new_path)
+        TemplateEditorDialog(self, template_type="yt_offline", initial_text=initial_text, on_save=on_save, initial_path=path)
+
+    def open_template_editor_newvideo(self):
+        from .template_editor_dialog import TemplateEditorDialog
+        path = self.tpl_newvideo.get()
+        initial_text = ""
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    initial_text = f.read()
+            except Exception:
+                pass
+        def on_save(new_path):
+            if new_path:
+                self.tpl_newvideo.set(new_path)
+        TemplateEditorDialog(self, template_type="yt_new_video", initial_text=initial_text, on_save=on_save, initial_path=path)

--- a/main.py
+++ b/main.py
@@ -75,6 +75,8 @@ if __name__ == "__main__":
                 time.sleep(1)
         except KeyboardInterrupt:
             signal_handler(signal.SIGINT, None)
+        # CUI終了時にトンネルも停止
+        stop_tunnel_and_monitor()
         cleanup_application()
     else:
         sys.exit(1)

--- a/niconico_monitor.py
+++ b/niconico_monitor.py
@@ -105,3 +105,21 @@ class NiconicoMonitor(Thread):
             context["live_id"] = entry.id
             context["stream_url"] = getattr(entry, "link", "")
         return context
+
+    def get_latest_live_id(self):
+        """
+        ユーザーの最新生放送IDを取得。
+        """
+        entry = self.get_latest_live_entry()
+        if entry:
+            return entry.id
+        return None
+
+    def get_latest_video_id(self):
+        """
+        ユーザーの最新動画IDを取得。
+        """
+        entry = self.get_latest_video_entry()
+        if entry:
+            return entry.id
+        return None

--- a/templates/twitch/twitch_offline_template.txt
+++ b/templates/twitch/twitch_offline_template.txt
@@ -1,8 +1,19 @@
 🛑 Twitch 配信終了
 
-{{ broadcaster_user_name | default('配信者名不明') }} さんのTwitch配信が終わりました。
+{{ broadcaster_user_name | default('配信者名不明') }} さんは、
+先ほどTwitchでの放送を終了しました。
 チャンネル: {{ channel_url | default('チャンネルURL不明') }}
 終了時刻: {{ ended_at | datetimeformat }}
+
+{% if to_broadcaster_user_name %}
+「Raid先のご案内」
+---
+{{ from_broadcaster_user_name | default('配信者名不明') }} さんの放送は、
+現在{{ to_broadcaster_user_name | default('Raid先不明') }} さんの放送にRaidされています。
+
+Raid先: {{ to_broadcaster_user_name }} ({{ to_broadcaster_user_login }})
+Raid先URL: {{ to_stream_url }}）
+{% endif %}
 
 またの配信をお楽しみに！
 #Twitch #配信終了

--- a/templates/twitch/twitch_offline_template.txt
+++ b/templates/twitch/twitch_offline_template.txt
@@ -2,6 +2,7 @@
 
 {{ broadcaster_user_name | default('配信者名不明') }} さんのTwitch配信が終わりました。
 チャンネル: {{ channel_url | default('チャンネルURL不明') }}
+終了時刻: {{ ended_at | datetimeformat }}
 
 またの配信をお楽しみに！
-#Twitch #配信終了 
+#Twitch #配信終了

--- a/templates/twitch/twitch_online_template.txt
+++ b/templates/twitch/twitch_online_template.txt
@@ -3,7 +3,7 @@ Twitch 放送開始 🎉
 配信者: {{ broadcaster_user_name }} 
 タイトル: {{ title }}
 カテゴリ: {{ category_name }}
-開始日時: {{ start_time | datetimeformat }}
+開始日時: {{ started_at | datetimeformat }}
 視聴URL: {{ stream_url }}
 
 ぜひ遊びに来てください！

--- a/templates/twitch/twitch_online_template.txt
+++ b/templates/twitch/twitch_online_template.txt
@@ -1,6 +1,6 @@
 Twitch 放送開始 🎉
 
-配信者: {{ broadcaster_user_name }} ({{ broadcaster_user_login }})
+配信者: {{ broadcaster_user_name }} 
 タイトル: {{ title }}
 カテゴリ: {{ category_name }}
 開始日時: {{ start_time | datetimeformat }}

--- a/templates/twitch/twitch_online_template.txt
+++ b/templates/twitch/twitch_online_template.txt
@@ -3,7 +3,7 @@ Twitch 放送開始 🎉
 配信者: {{ broadcaster_user_name }} 
 タイトル: {{ title }}
 カテゴリ: {{ category_name }}
-開始日時: {{ started_at | datetimeformat }}
+開始日時: {{ started_at | datetimeformat}}
 視聴URL: {{ stream_url }}
 
 ぜひ遊びに来てください！

--- a/templates/twitch/twitch_raid_template.txt
+++ b/templates/twitch/twitch_raid_template.txt
@@ -1,0 +1,10 @@
+🚀 Twitch Raid 終了通知
+
+{{ from_broadcaster_user_name | default('配信者名不明') }} さんが配信を終了し、
+{{ to_broadcaster_user_name | default('Raid先不明') }} さんのチャンネルにRaidしました！
+
+Raid先: {{ to_broadcaster_user_name }} ({{ to_broadcaster_user_login }})
+Raid先URL: https://twitch.tv/{{ to_broadcaster_user_login }}
+視聴者数: {{ viewers | default('不明') }}
+
+#Twitch #Raid #配信終了

--- a/templates/twitch/twitch_raid_template.txt
+++ b/templates/twitch/twitch_raid_template.txt
@@ -1,9 +1,0 @@
-🚀 Twitch Raid 終了通知
-
-{{ from_broadcaster_user_name | default('配信者名不明') }} さんが配信を終了し、
-{{ to_broadcaster_user_name | default('Raid先不明') }} さんのチャンネルにRaidしました！
-
-Raid先: {{ to_broadcaster_user_name }} ({{ to_broadcaster_user_login }})
-Raid先URL: https://twitch.tv/{{ to_broadcaster_user_login }}
-
-#Twitch #Raid #配信終了

--- a/templates/twitch/twitch_raid_template.txt
+++ b/templates/twitch/twitch_raid_template.txt
@@ -5,6 +5,5 @@
 
 Raid先: {{ to_broadcaster_user_name }} ({{ to_broadcaster_user_login }})
 Raid先URL: https://twitch.tv/{{ to_broadcaster_user_login }}
-視聴者数: {{ viewers | default('不明') }}
 
 #Twitch #Raid #配信終了

--- a/tests/test_youtube_niconico_monitor.py
+++ b/tests/test_youtube_niconico_monitor.py
@@ -83,25 +83,24 @@ def dummy_niconico_monitor(monkeypatch):
     monitor.live_called = False
     monitor.video_called = False
 
-    def fake_get_latest_live_id(self):
-        # 1回だけ生放送IDを返す
-        if not hasattr(self, "_called_live"):
-            self._called_live = True
-            return "dummy_live_id"
-        return "dummy_live_id"
+    def fake_entry(kind):
+        class DummyEntry:
+            id = f"dummy_{kind}_id"
+            title = f"dummy_{kind}_title"
+            author = f"dummy_{kind}_author"
+            published = "2025-01-01T00:00:00"
+            link = f"https://example.com/{kind}"
+        return DummyEntry()
 
-    def fake_get_latest_video_id(self):
-        # 1回だけ動画IDを返す
-        if not hasattr(self, "_called_video"):
-            self._called_video = True
-            return "dummy_video_id"
-        return "dummy_video_id"
+    def fake_get_latest_live_entry(self):
+        return fake_entry("live")
+
+    def fake_get_latest_video_entry(self):
+        return fake_entry("video")
 
     # モックメソッドをNiconicoMonitorに差し替え
-    monkeypatch.setattr(NiconicoMonitor, "get_latest_live_id",
-                        fake_get_latest_live_id)
-    monkeypatch.setattr(
-        NiconicoMonitor, "get_latest_video_id", fake_get_latest_video_id)
+    monkeypatch.setattr(NiconicoMonitor, "get_latest_live_entry", fake_get_latest_live_entry)
+    monkeypatch.setattr(NiconicoMonitor, "get_latest_video_entry", fake_get_latest_video_entry)
     return monitor
 
 


### PR DESCRIPTION
このプルリクエストでは、複数のファイルにわたる複数の機能強化と修正を導入し、テンプレート処理の改善、Raid固有の変数への対応追加、およびユーザーインターフェースの最適化によるユーザー体験の向上に焦点を当てています。変更内容は、以下の3つの主要なテーマに分類されています：テンプレート処理の改善、Raid対応、およびGUIの機能強化。

### テンプレート処理の改善:
* グローバルフィルターの登録に`jinja2.Template`から`jinja2.Environment`へ切り替え、テンプレートの柔軟性を向上（`bluesky.py`）。
* Twitch API経由でチャンネル情報を取得する新しいメソッドを追加（`eventsub.py`）。

### Raidサポート:
* テンプレートにRaid専用の変数（`from_broadcaster_user_name`、`to_broadcaster_user_name`など）を導入し、これらの変更を反映するためにドキュメントを更新しました（`document/投稿テンプレートの引数.md`、`bluesky.py`）。[[1]](diffhunk://#diff-e207a0ed81d3c3f486f7c60a422b771d5d47b52aa168d0669677e0bf337ebf43R18-R30) [[2]](diffhunk://#diff-1d3fd851c68ef849effc892b98c69718d7e0b084ae323304522ba427864a6e92L219-R246)
* `post_stream_offline` のロジックを更新し、Raid 専用のテンプレートと変数に対応するようにしました（`bluesky.py`）。[[1]](diffhunk://#diff-1d3fd851c68ef849effc892b98c69718d7e0b084ae323304522ba427864a6e92L219-R246) [[2]](diffhunk://#diff-1d3fd851c68ef849effc892b98c69718d7e0b084ae323304522ba427864a6e92L264-R274)

### GUIの機能強化:
* GUIから直接新しいテンプレートを作成できる「テンプレート作成」ボタンを追加しました（`gui/bluesky_post_settings_frame.py`）。
* テンプレートエディターダイアログを強化し、Raid固有の変数に対応させ、新しいテンプレートと既存のテンプレートのプレビュー機能を追加しました（`gui/template_editor_dialog.py`）。[[1]](diffhunk://#diff-b345b526c9c17e1117ccc6b98ee328935cac2d95356e14f30fcce699ab5bdc1fR160-R184) [[2]](diffhunk://#diff-b345b526c9c17e1117ccc6b98ee328935cac2d95356e14f30fcce699ab5bdc1fR207-R219)
* ニコニコ通知フレーム内の特定のアクション用に専用の「編集テンプレート」ボタンを追加しました（`gui/niconico_notice_frame.py`）。[[1]](diffhunk://#diff-f5224e79165fe22e3376f84949273c8c9242ed3adf26aaabba1faf6df2f80147R76-R81) [[2]](diffhunk://#diff-f5224e79165fe22e3376f84949273c8c9242ed3adf26aaabba1faf6df2f80147R203-R232)